### PR TITLE
Support key/value pairs for keyvalue store.

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,13 @@ curl -X POST http://localhost:3000/db/docstore/put -H "Content-Type: application
 zdpuAkkFaimxyRE2bsiLRSiybkku3oDi4vFHqPZh29BABZtZU
 ```
 
+For the keyvalue store, a JSON object containing the variables `key` and
+`value` must be passed in the POST data:
+
+```shell
+curl -X POST http://localhost:3001/db/keyvalue/put  -H "Content-Type: application/json" -d '{"key":"Key","value":{ "name": "Value" }}'
+```
+
 ### POST|PUT /db/:dbname/inc
 
 Increments the counter database :dbname by 1.

--- a/src/lib/orbitdb-api.js
+++ b/src/lib/orbitdb-api.js
@@ -69,7 +69,7 @@ class OrbitdbAPI extends Express {
 
             if (db.type == 'keyvalue') {
                 let params = req.body;
-                hash = await db.put(params.key, JSON.parse(params.value))
+                hash = await db.put(params.key, params.value)
             } else {
                 hash = await db.put(req.body)
             }

--- a/src/lib/orbitdb-api.js
+++ b/src/lib/orbitdb-api.js
@@ -66,7 +66,14 @@ class OrbitdbAPI extends Express {
         var db_put = asyncMiddleware( async (req, res, next) => {
             let db, hash
             db = await dbm.get(req.params.dbname)
-            hash = await db.put(req.body)
+
+            if (db.type == 'keyvalue') {
+                let params = req.body;
+                hash = await db.put(params.key, JSON.parse(params.value))
+            } else {
+                hash = await db.put(req.body)
+            }
+
             return res.json(hash)
         });
 


### PR DESCRIPTION
To test:

create a keyvalue store:

`curl http://localhost:3000/db/keyvalue --data 'create=true' --data 'type=keyvalue'`

write a key/object-value to the store:

`curl -X POST http://localhost:3000/db/keyvalue/put  -H "Content-Type: application/json" -d '{"key":"mykey","value":"{ name: \"World\" }"}'`

It should correctly parse the JSON and store a JS object against the key.

A simple:

`console.log(db._index)`

should show the full list correctly written to the keyvalue store.