### PR TITLE
docs: README now points to orbit-db-http-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To install the OrbitDB HTTP Client:
 
 ```shell
 git clone https://github.com/orbitdb/orbit-db-http-api.git
-cd orbit-db-api
+cd orbit-db-http-api
 npm install
 ```
 


### PR DESCRIPTION
Tiny patch to move the first install step to the correct directory, resulting from the clone command.